### PR TITLE
bug: Fix leaving rooms

### DIFF
--- a/socketio_middleware/src/rooms.rs
+++ b/socketio_middleware/src/rooms.rs
@@ -50,7 +50,7 @@ pub fn remove_socket_from_room(room_id: &str, _sid: &str) {
     };
 
     for i in 0..connected_sockets.len() - 1 {
-        let i = connected_sockets.len() - i;
+        let i = connected_sockets.len() - 1 - i;
         let socket = connected_sockets.get(i).unwrap();
 
         if socket.sid == room_id {


### PR DESCRIPTION
We were getting an index issue when leaving the room. This happened because when we reverse iterated we were starting from the length, not the length - 1.